### PR TITLE
add more invalid examples of objects that implement the acceleration interface

### DIFF
--- a/src/acceleration/is-acceleration.test.ts
+++ b/src/acceleration/is-acceleration.test.ts
@@ -12,7 +12,18 @@ const validExamples = [
   { x: -567.89, y: 8 },
 ];
 
-const invalidExamples = [{ entity: "foo" }, { id: "bar" }];
+const invalidExamples = [
+  { entity: "foo" },
+  { id: "bar" },
+  false,
+  "baz",
+  123,
+  { x: 0 },
+  { y: 92 },
+  { x: 15, y: "foo" },
+  { x: false, y: 1 },
+  { x: "bar", y: "baz" },
+];
 
 describe("The isAcceleration type-guard function", () => {
   describe("should return true", () => {


### PR DESCRIPTION
closes #3 